### PR TITLE
Enrich Facebook Ads dimension names

### DIFF
--- a/models/marts/social_paid/facebook_ads/intermediate/facebook_ads__creatives_conversions_joined.sql
+++ b/models/marts/social_paid/facebook_ads/intermediate/facebook_ads__creatives_conversions_joined.sql
@@ -1,3 +1,6 @@
+{# Get a list of the columns from the upstream model #}
+{%- set cols = adapter.get_columns_in_relation(ref('stg_facebook_ads__creative')) -%}
+
 {#- Get a list of the Facebook Ads conversions that are active for the Facebook Ads accounts -#}
 {%- set conversions = dbt_utils.get_query_results_as_dict("select * from" ~ ref('facebook_ads__creatives_conversions')) -%}
 {%- set active_conversions = [] -%}
@@ -19,101 +22,21 @@ final AS (
 
     SELECT
     
-        {# Dimensions -#}
-        id,
-        data_source,
-        channel_source_name,
-        channel_source_type,
-        channel_name,
-        account_id,
-        account_name,
-        date,
-        campaign_id,
-        campaign_name,
-        campaign_type,
-        adset_id,
-        adset_name,
-        ad_id,
-        ad_name,
-        creative_id,
-        creative_name,
-        ad_objective,
-        ad_publication_date,
-        ad_type,
-        body,
-        name,
-        description,
-        caption,
-        call_to_action_type,
-        format_option,
-        preview_shareable_link,
-        instagram_permalink_url,
-        creative_link,
-        image,
-        image_url,
-        website_destination_url,
-        creative_destination_url,
-        video_creative_destination_url,
-        buying_type,
-        lead_gen_form_id,
-        object_story_id,
-        effective_object_story_id,
-        effective_status,
-        
-        {#- General metrics -#}
-        reach,
-        impressions,
-        cost,
-        clicks,
-        outbound_clicks,
-        all_clicks,
-        inline_link_clicks,
-        unique_clicks,
-        unique_link_click,
+        {# Dimensions and non-Conversion Metrics -#}
 
-        {#- Engagement metrics -#}
-        post_engagement_total,
-        inline_post_engagement,
-        post_reactions,
-        post_likes,
-        post_comments,
-        post_shares,
-        post_saves,
-        post_story_total,
-        page_engagement_total,
-        page_story_total,
-        page_likes,
-        app_engagement_total,
-        app_story_total,
-        app_use,
-        mobile_app_install,
-        instagram_profile_engagement_total,
-
-        {#- Video metrics -#}
-        video_view_3s,
-        video_views,
-        video_play_actions_view_value,
-        video_p25_watched,
-        video_p50_watched,
-        video_p75_watched,
-        video_p95_watched,
-        video_completions,
-        video_thru_play,
-        video_30_sec_watched_actions,
-        video_avg_time_watched_actions,
-        video_average_play_time_count
+        {#- Loop through each upstream model column that is not a conversion -#}
+        {%- for col in cols if "conv_" not in col.column -%}
+            {{ col.column }}{% if not loop.last or active_conversions != [] %},{% endif %}
+        {% endfor %}
 
         {#- Conversions -#}
 
         {#- Loop through each active conversion -#}
         {%- for conv in active_conversions -%}
+            {{ conv }}{% if not loop.last %},{% endif %}
+        {% endfor %}
         
-        ,
-        {{ conv }}
-
-        {%- endfor %}
-        
-     FROM data
+    FROM data
 
 )
   

--- a/models/staging/facebook_ads/src_facebook_ads.yml
+++ b/models/staging/facebook_ads/src_facebook_ads.yml
@@ -22,3 +22,15 @@ sources:
       - name: facebook_campaign_month_reach
         identifier: 'facebook_campaign_month_reach_*'
         loaded_at_field: TIMESTAMP(end_date)
+
+      - name: facebook_entity_ads
+        identifier: 'facebook_entity_ads_*'
+    
+      - name: facebook_entity_adsets
+        identifier: 'facebook_entity_adsets_*'
+
+      - name: facebook_entity_campaigns
+        identifier: 'facebook_entity_campaigns_*'
+      
+      - name: facebook_entity_creatives
+        identifier: 'facebook_entity_creatives_*'

--- a/models/staging/facebook_ads/stg_facebook_ads.yml
+++ b/models/staging/facebook_ads/stg_facebook_ads.yml
@@ -27,3 +27,39 @@ models:
         tests:
           - unique
           - not_null
+  
+  - name: stg_facebook_ads__entity_ads
+    description: A table containing dimension data for ads from Facebook Ads
+    columns:
+      - name: ad_id
+        description: Primary key
+        tests:
+          - unique
+          - not_null
+  
+  - name: stg_facebook_ads__entity_adsets
+    description: A table containing dimension data for adsets from Facebook Ads
+    columns:
+      - name: adset_id
+        description: Primary key
+        tests:
+          - unique
+          - not_null
+  
+  - name: stg_facebook_ads__entity_campaigns
+    description: A table containing dimension data for campaigns from Facebook Ads
+    columns:
+      - name: campaign_id
+        description: Primary key
+        tests:
+          - unique
+          - not_null
+  
+  - name: stg_facebook_ads__entity_creatives
+    description: A table containing dimension data for creatives from Facebook Ads
+    columns:
+      - name: creative_id
+        description: Primary key
+        tests:
+          - unique
+          - not_null

--- a/models/staging/facebook_ads/stg_facebook_ads__campaign_month_reach.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__campaign_month_reach.sql
@@ -10,17 +10,25 @@ source_data AS (
 
 ),
 
+facebook_entity_campaign_data AS (
+
+    SELECT * FROM {{ ref('stg_facebook_ads__entity_campaigns') }}
+
+),
+
 rename_recast AS (
 
     SELECT
 
         {# Dimensions -#}
-        account_id,
-        account_name,
-        date AS month_start_date,
-        end_date AS month_end_date,
-        campaign_id,
-        campaign_name,
+        source_data.account_id,
+        facebook_entity_campaign_data.account_name AS account_name,
+        source_data.account_name AS account_name_on_date,
+        source_data.date AS month_start_date,
+        source_data.end_date AS month_end_date,
+        source_data.campaign_id,
+        facebook_entity_campaign_data.campaign_name AS campaign_name,
+        source_data.campaign_name AS campaign_name_on_date,
 
         {#- General metrics -#}
         reach,
@@ -42,6 +50,9 @@ rename_recast AS (
 
 
     FROM source_data
+
+    LEFT JOIN facebook_entity_campaign_data
+        ON source_data.campaign_id = facebook_entity_campaign_data.campaign_id
 
 ),
 

--- a/models/staging/facebook_ads/stg_facebook_ads__creative.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__creative.sql
@@ -13,45 +13,74 @@ source_data AS (
 
 ),
 
+facebook_entity_ad_data AS (
+
+    SELECT * FROM {{ ref('stg_facebook_ads__entity_ads') }}
+
+),
+
+facebook_entity_adset_data AS (
+
+    SELECT * FROM {{ ref('stg_facebook_ads__entity_adsets') }}
+
+),
+
+facebook_entity_campaign_data AS (
+
+    SELECT * FROM {{ ref('stg_facebook_ads__entity_campaigns') }}
+
+),
+
+facebook_entity_creative_data AS (
+
+    SELECT * FROM {{ ref('stg_facebook_ads__entity_creatives') }}
+
+),
+
 rename_recast AS (
 
     SELECT
 
         {# Dimensions -#}
-        account_id,
-        account_name,
-        date,
-        campaign_id,
-        campaign_name,
-        campaign_type,
-        adset_id,
-        adset_name,
-        ad_id,
-        ad_name,
-        creative_id,
-        creative_name,
-        objective AS ad_objective,
-        DATE(CAST(publication_date AS DATETIME)) AS ad_publication_date,
-        object_type AS ad_type,
-        body,
-        name,
-        description,
-        caption,
-        call_to_action_type,
-        format_option,
-        preview_shareable_link,
-        instagram_permalink_url,
-        creative_link,
-        image,
-        image_url,
-        website_destination_url,
-        creative_destination_url,
-        video_creative_destination_url,
-        buying_type,
-        lead_gen_form_id,
-        object_story_id,
-        effective_object_story_id,
-        effective_status,
+        source_data.account_id,
+        facebook_entity_ad_data.account_name AS account_name,
+        source_data.account_name AS account_name_on_date,
+        source_data.date,
+        source_data.campaign_id,
+        facebook_entity_campaign_data.campaign_name AS campaign_name,
+        source_data.campaign_name AS campaign_name_on_date,
+        source_data.campaign_type,
+        source_data.adset_id,
+        facebook_entity_adset_data.adset_name AS adset_name,
+        source_data.adset_name AS adset_name_on_date,
+        source_data.ad_id,
+        facebook_entity_ad_data.ad_name AS ad_name,
+        source_data.ad_name AS ad_name_on_date,
+        source_data.creative_id,
+        facebook_entity_creative_data.creative_name AS creative_name,
+        source_data.creative_name AS creative_name_on_date,
+        source_data.objective AS ad_objective,
+        DATE(CAST(source_data.publication_date AS DATETIME)) AS ad_publication_date,
+        source_data.object_type AS ad_type,
+        source_data.body,
+        source_data.name,
+        source_data.description,
+        source_data.caption,
+        source_data.call_to_action_type,
+        source_data.format_option,
+        source_data.preview_shareable_link,
+        source_data.instagram_permalink_url,
+        source_data.creative_link,
+        source_data.image,
+        source_data.image_url,
+        source_data.website_destination_url,
+        source_data.creative_destination_url,
+        source_data.video_creative_destination_url,
+        source_data.buying_type,
+        source_data.lead_gen_form_id,
+        source_data.object_story_id,
+        source_data.effective_object_story_id,
+        source_data.effective_status,
         
         {#- General metrics -#}
         reach,
@@ -214,6 +243,18 @@ rename_recast AS (
         */
 
     FROM source_data
+
+    LEFT JOIN facebook_entity_ad_data
+        ON source_data.ad_id = facebook_entity_ad_data.ad_id
+
+    LEFT JOIN facebook_entity_adset_data
+        ON source_data.adset_id = facebook_entity_adset_data.adset_id
+
+    LEFT JOIN facebook_entity_campaign_data
+        ON source_data.campaign_id = facebook_entity_campaign_data.campaign_id
+
+    LEFT JOIN facebook_entity_creative_data
+        ON source_data.creative_id = facebook_entity_creative_data.creative_id
 
 ),
 

--- a/models/staging/facebook_ads/stg_facebook_ads__entity_ads.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__entity_ads.sql
@@ -1,0 +1,68 @@
+{%- set source_account_ids = var('facebook_ads_ids') -%}
+
+WITH
+
+source_data AS (
+
+    SELECT * FROM {{ source('improvado', 'facebook_entity_ads') }}
+
+    WHERE account_id IN UNNEST({{ source_account_ids }})
+
+),
+
+rename_recast_dedupe AS (
+
+    SELECT DISTINCT
+
+        account_id,
+        account_name,
+        id AS ad_id,
+        name AS ad_name,
+        adset_id,
+        campaign_id,
+        creative_id,
+        date,
+        created_time,
+        updated_time,
+        effective_status,
+        status
+
+    FROM source_data
+
+),
+
+rank_duplicate_ad_ids AS (
+
+    SELECT
+
+        *,
+        ROW_NUMBER() OVER (PARTITION BY ad_id ORDER BY updated_time DESC) AS rank_recent
+
+    FROM rename_recast_dedupe
+
+),
+
+final AS (
+
+    SELECT
+
+        account_id,
+        account_name,
+        ad_id,
+        ad_name,
+        adset_id,
+        campaign_id,
+        creative_id,
+        date,
+        created_time,
+        updated_time,
+        effective_status,
+        status
+
+    FROM rank_duplicate_ad_ids
+
+    WHERE rank_recent = 1
+
+)
+
+SELECT * FROM final

--- a/models/staging/facebook_ads/stg_facebook_ads__entity_adsets.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__entity_adsets.sql
@@ -1,0 +1,76 @@
+{%- set source_account_ids = var('facebook_ads_ids') -%}
+
+WITH
+
+source_data AS (
+
+    SELECT * FROM {{ source('improvado', 'facebook_entity_adsets') }}
+
+    WHERE account_id IN UNNEST({{ source_account_ids }})
+
+),
+
+rename_recast_dedupe AS (
+
+    SELECT DISTINCT
+
+        account_id,
+        account_name,
+        adset_id,
+        name AS adset_name,
+        campaign_id,
+        date,
+        created_time,
+        updated_time,
+        destination_type,
+        effective_status,
+        optimization_goal,
+        start_time,
+        end_time,
+        targeting,
+        daily_budget,
+        lifetime_budget
+
+    FROM source_data
+
+),
+
+rank_duplicate_adset_ids AS (
+
+    SELECT
+
+        *,
+        ROW_NUMBER() OVER (PARTITION BY adset_id ORDER BY updated_time DESC) AS rank_recent
+
+    FROM rename_recast_dedupe
+
+),
+
+final AS (
+
+    SELECT
+
+        account_id,
+        account_name,
+        adset_id,
+        adset_name,
+        campaign_id,
+        date,
+        created_time,
+        updated_time,
+        destination_type,
+        effective_status,
+        optimization_goal,
+        start_time,
+        end_time,
+        targeting,
+        daily_budget,
+        lifetime_budget
+
+    FROM rank_duplicate_adset_ids
+
+    WHERE rank_recent = 1
+
+)
+
+SELECT * FROM final

--- a/models/staging/facebook_ads/stg_facebook_ads__entity_campaigns.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__entity_campaigns.sql
@@ -1,0 +1,80 @@
+{%- set source_account_ids = var('facebook_ads_ids') -%}
+
+WITH
+
+source_data AS (
+
+    SELECT * FROM {{ source('improvado', 'facebook_entity_campaigns') }}
+
+    WHERE account_id IN UNNEST({{ source_account_ids }})
+
+),
+
+rename_recast_dedupe AS (
+
+    SELECT DISTINCT
+
+        account_id,
+        account_name,
+        campaign_id,
+        campaign_name,
+        date,
+        bid_strategy,
+        buying_type,
+        daily_budget,
+        lifetime_budget,
+        effective_status,
+        configured_status,
+        status,
+        objective,
+        spend_cap,
+        start_time,
+        stop_time,
+        created_time,
+        updated_time
+
+    FROM source_data
+
+),
+
+rank_duplicate_campaign_ids AS (
+
+    SELECT
+
+        *,
+        ROW_NUMBER() OVER (PARTITION BY campaign_id ORDER BY updated_time DESC) AS rank_recent
+
+    FROM rename_recast_dedupe
+
+),
+
+final AS (
+
+    SELECT
+
+        account_id,
+        account_name,
+        campaign_id,
+        campaign_name,
+        date,
+        bid_strategy,
+        buying_type,
+        daily_budget,
+        lifetime_budget,
+        effective_status,
+        configured_status,
+        status,
+        objective,
+        spend_cap,
+        start_time,
+        stop_time,
+        created_time,
+        updated_time
+
+    FROM rank_duplicate_campaign_ids
+
+    WHERE rank_recent = 1
+
+)
+
+SELECT * FROM final

--- a/models/staging/facebook_ads/stg_facebook_ads__entity_creatives.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__entity_creatives.sql
@@ -1,0 +1,118 @@
+{%- set source_account_ids = var('facebook_ads_ids') -%}
+
+WITH
+
+source_data AS (
+
+    SELECT * FROM {{ source('improvado', 'facebook_entity_creatives') }}
+
+    WHERE account_id IN UNNEST({{ source_account_ids }})
+
+),
+
+rename_recast_dedupe AS (
+
+    SELECT DISTINCT
+
+        account_id,
+        account_name,
+        date,
+        creative_id,
+        actor_id,
+        applink_treatment,
+        body,
+        branded_content_sponsor_page_id,
+        call_to_action_type,
+        effective_instagram_story_id,
+        effective_object_story_id,
+        image_hash,
+        image_url,
+        instagram_actor_id,
+        instagram_permalink_url,
+        instagram_story_id,
+        link_og_id,
+        link_url,
+        name,
+        object_id,
+        object_story_id,
+        object_type,
+        object_url,
+        product_set_id,
+        status,
+        template_url,
+        thumbnail_url,
+        title,
+        url_tags,
+        use_page_actor_override,
+        video_id,
+        creative_destination_url,
+        description,
+        caption,
+        creative_link,
+        lead_gen_form_id,
+        template_data_link
+
+    FROM source_data
+
+),
+
+rank_duplicate_ad_ids AS (
+
+    SELECT
+
+        *,
+        ROW_NUMBER() OVER (PARTITION BY creative_id ORDER BY date DESC) AS rank_recent
+
+    FROM rename_recast_dedupe
+
+),
+
+final AS (
+
+    SELECT
+
+        account_id,
+        account_name,
+        date,
+        creative_id,
+        actor_id,
+        applink_treatment,
+        body,
+        branded_content_sponsor_page_id,
+        call_to_action_type,
+        effective_instagram_story_id,
+        effective_object_story_id,
+        image_hash,
+        image_url,
+        instagram_actor_id,
+        instagram_permalink_url,
+        instagram_story_id,
+        link_og_id,
+        link_url,
+        name AS creative_name,
+        object_id,
+        object_story_id,
+        object_type,
+        object_url,
+        product_set_id,
+        status,
+        template_url,
+        thumbnail_url,
+        title,
+        url_tags,
+        use_page_actor_override,
+        video_id,
+        creative_destination_url,
+        description,
+        caption,
+        creative_link,
+        lead_gen_form_id,
+        template_data_link
+
+    FROM rank_duplicate_ad_ids
+
+    WHERE rank_recent = 1
+
+)
+
+SELECT * FROM final

--- a/models/staging/facebook_ads/stg_facebook_ads__placements.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__placements.sql
@@ -13,27 +13,49 @@ source_data AS (
 
 ),
 
+facebook_entity_ad_data AS (
+
+    SELECT * FROM {{ ref('stg_facebook_ads__entity_ads') }}
+
+),
+
+facebook_entity_adset_data AS (
+
+    SELECT * FROM {{ ref('stg_facebook_ads__entity_adsets') }}
+
+),
+
+facebook_entity_campaign_data AS (
+
+    SELECT * FROM {{ ref('stg_facebook_ads__entity_campaigns') }}
+
+),
+
 rename_recast AS (
 
     SELECT
 
         {# Dimensions -#}
-        account_id,
-        account_name,
-        date,
-        campaign_id,
-        campaign_name,
+        source_data.account_id,
+        facebook_entity_ad_data.account_name AS account_name,
+        source_data.account_name AS account_name_on_date,
+        source_data.date,
+        source_data.campaign_id,
+        facebook_entity_campaign_data.campaign_name AS campaign_name,
+        source_data.campaign_name AS campaign_name_on_date,
         campaign_type,
-        adset_id,
-        adset_name,
-        ad_id,
-        ad_name,
-        objective AS ad_objective,
-        DATE(CAST(created_time AS DATETIME)) AS ad_publication_date,
-        effective_status,
-        impression_device,
-        publisher_platform,
-        platform_position,
+        source_data.adset_id,
+        facebook_entity_adset_data.adset_name AS adset_name,
+        source_data.adset_name AS adset_name_on_date,
+        source_data.ad_id,
+        facebook_entity_ad_data.ad_name AS ad_name,
+        source_data.ad_name AS ad_name_on_date,
+        source_data.objective AS ad_objective,
+        DATE(CAST(source_data.created_time AS DATETIME)) AS ad_publication_date,
+        source_data.effective_status,
+        source_data.impression_device,
+        source_data.publisher_platform,
+        source_data.platform_position,
         
         {# General metrics -#}
         reach,
@@ -216,6 +238,15 @@ rename_recast AS (
         */
 
     FROM source_data
+
+    LEFT JOIN facebook_entity_ad_data
+        ON source_data.ad_id = facebook_entity_ad_data.ad_id
+
+    LEFT JOIN facebook_entity_adset_data
+        ON source_data.adset_id = facebook_entity_adset_data.adset_id
+
+    LEFT JOIN facebook_entity_campaign_data
+        ON source_data.campaign_id = facebook_entity_campaign_data.campaign_id
 
 ),
 


### PR DESCRIPTION
Added staging models for Facebook Ads campaign, adset, ad, and creative entities. Enriched Facebook Ad staging models with data from entities to include the most current names for account, campaign, adset, ad, and creative.