### PR TITLE
event_responses metric added to stg_facebook_ads__creative model

### DIFF
--- a/models/facebook_ads/staging/stg_facebook_ads__creative.sql
+++ b/models/facebook_ads/staging/stg_facebook_ads__creative.sql
@@ -119,6 +119,7 @@ rename_recast AS (
         action_comment_value AS post_comments,
         action_post_value AS post_shares,
         action_like_value AS post_likes,
+        event_responses,
 
         {#- Video metrics -#}
         views AS video_views,


### PR DESCRIPTION
Added the event_responses metric to the stg_facebook_ads__creative model under the {#- Engagement metrics -#} section because that's where it's located in the stg_facebook_ads__placements model.