### PR TITLE
Facebook page follower metric updated to page_follows

### DIFF
--- a/models/rollups/social_organic/intermediate/prep_rollup_social_organic__followers_daily_facebook.sql
+++ b/models/rollups/social_organic/intermediate/prep_rollup_social_organic__followers_daily_facebook.sql
@@ -34,8 +34,8 @@ final AS (
         channel_name,
         date,
         
-        page_fans AS social_followers_total,
-        page_fans - LAG(page_fans) OVER (PARTITION BY account_id ORDER BY date ASC) AS social_followers_net
+        page_follows AS social_followers_total,
+        page_follows - LAG(page_follows) OVER (PARTITION BY account_id ORDER BY date ASC) AS social_followers_net
         
      FROM general_definitions
 


### PR DESCRIPTION
In the prep_rollup_social_organic__followers_daily_facebook model - updated the followers metric to be page_follows instead of page_fans