### PR TITLE
Updated Google Ads Ad-Level staging and intermediate tables, to refer…

### DIFF
--- a/models/google_ads/intermediate/google_ads__ads_aggregated.sql
+++ b/models/google_ads/intermediate/google_ads__ads_aggregated.sql
@@ -25,7 +25,7 @@ final AS (
 
     SELECT
         
-        {{ dbt_utils.generate_surrogate_key(['date', 'account_id', 'ad_id', 'ad_network_type']) }} AS id,
+        {{ dbt_utils.generate_surrogate_key(['date', 'account_id', 'campaign_id', 'ad_group_id', 'ad_id', 'ad_network_type']) }} AS id,
         *
     
     FROM aggregate

--- a/models/google_ads/intermediate/google_ads__ads_conversions_pivoted.sql
+++ b/models/google_ads/intermediate/google_ads__ads_conversions_pivoted.sql
@@ -116,7 +116,7 @@ final AS (
 
     SELECT
         
-        {{ dbt_utils.generate_surrogate_key(['date', 'account_id', 'ad_id', 'ad_network_type']) }} AS id,
+        {{ dbt_utils.generate_surrogate_key(['date', 'account_id', 'campaign_id', 'ad_group_id', 'ad_id', 'ad_network_type']) }} AS id,
         *
     
     FROM pivot_conversions

--- a/models/google_ads/staging/stg_google_ads__ad_conversions.sql
+++ b/models/google_ads/staging/stg_google_ads__ad_conversions.sql
@@ -62,7 +62,7 @@ final AS (
   
     SELECT 
     
-        {{ dbt_utils.generate_surrogate_key(['date', 'account_id', 'ad_id', 'ad_network_type', 'device', 'conversion_action_id']) }} AS id,
+        {{ dbt_utils.generate_surrogate_key(['date', 'account_id', 'campaign_id', 'ad_group_id', 'ad_id', 'ad_network_type', 'device', 'conversion_action_id']) }} AS id,
         'Google Ads' AS data_source,
         'Google' AS channel_source_name,
         'Paid' AS channel_source_type,

--- a/models/google_ads/staging/stg_google_ads__ads.sql
+++ b/models/google_ads/staging/stg_google_ads__ads.sql
@@ -107,7 +107,7 @@ final AS (
   
     SELECT 
     
-        {{ dbt_utils.generate_surrogate_key(['date', 'account_id', 'ad_id', 'ad_network_type']) }} AS id,
+        {{ dbt_utils.generate_surrogate_key(['date', 'account_id', 'campaign_id', 'ad_group_id', 'ad_id', 'ad_network_type']) }} AS id,
         'Google Ads' AS data_source,
         'Google' AS channel_source_name,
         'Paid' AS channel_source_type,


### PR DESCRIPTION
…ence Campaign ID and Ad Group ID, in the DBT surrogate ID to stop duplication in unique tests